### PR TITLE
Fix paper compilation

### DIFF
--- a/ms/paper.md
+++ b/ms/paper.md
@@ -13,7 +13,7 @@ output: pdf_document
 authors:
 - name: Yizhou Liu
   affiliation: 1
-- name: Claudia Solis-Lemus^[Corresponding author (solislemus@wisc.edu)]
+- name: Claudia Solis-Lemus^[Corresponding author (solislemus\@wisc.edu)]
   orcid: 0000-0002-9789-8915
   affiliation: 2
 bibliography: paper.bib


### PR DESCRIPTION
This PR fixes the error compiling the paper for the [JOSE review](https://github.com/openjournals/jose-reviews/issues/103)
The problem was the `@` in the author's footnote